### PR TITLE
Add knowledge base content types and seeding

### DIFF
--- a/data/data.json
+++ b/data/data.json
@@ -93,7 +93,10 @@
         },
         {
           "__component": "shared.slider",
-          "files": ["coffee-art.jpg", "coffee-beans.jpg"]
+          "files": [
+            "coffee-art.jpg",
+            "coffee-beans.jpg"
+          ]
         }
       ]
     },
@@ -128,7 +131,10 @@
         },
         {
           "__component": "shared.slider",
-          "files": ["coffee-art.jpg", "coffee-beans.jpg"]
+          "files": [
+            "coffee-art.jpg",
+            "coffee-beans.jpg"
+          ]
         }
       ]
     },
@@ -163,7 +169,10 @@
         },
         {
           "__component": "shared.slider",
-          "files": ["coffee-art.jpg", "coffee-beans.jpg"]
+          "files": [
+            "coffee-art.jpg",
+            "coffee-beans.jpg"
+          ]
         }
       ]
     },
@@ -198,7 +207,10 @@
         },
         {
           "__component": "shared.slider",
-          "files": ["coffee-art.jpg", "coffee-beans.jpg"]
+          "files": [
+            "coffee-art.jpg",
+            "coffee-beans.jpg"
+          ]
         }
       ]
     },
@@ -233,9 +245,215 @@
         },
         {
           "__component": "shared.slider",
-          "files": ["coffee-art.jpg", "coffee-beans.jpg"]
+          "files": [
+            "coffee-art.jpg",
+            "coffee-beans.jpg"
+          ]
         }
       ]
     }
-  ]
+  ],
+  "knowledgeBase": {
+    "global": {
+      "title": "Strapi Knowledge Base",
+      "slug": "strapi-knowledge-base",
+      "summary": "Guides and updates that help every team succeed with Strapi.",
+      "heroTitle": "Welcome to the Strapi Knowledge Base",
+      "heroDescription": "Explore curated guides, resources, and release highlights tailored to your team.",
+      "resources": [
+        {
+          "title": "Strapi Documentation",
+          "summary": "Browse the official documentation covering every Strapi feature.",
+          "url": "https://docs.strapi.io"
+        },
+        {
+          "title": "Product Roadmap",
+          "summary": "See what's shipping next and follow along with the roadmap.",
+          "url": "https://portal.productboard.com/strapi"
+        }
+      ]
+    },
+    "audiences": [
+      {
+        "name": "Developers",
+        "slug": "developers",
+        "summary": "Build integrations, extend Strapi, and automate your content workflows.",
+        "description": "Developers get deep technical guidance, API references, and best practices for building production-ready applications with Strapi.",
+        "resources": [
+          {
+            "title": "API Tokens",
+            "summary": "Authenticate requests securely with Strapi's API tokens.",
+            "url": "https://docs.strapi.io/dev-docs/configurations/authentication"
+          }
+        ]
+      },
+      {
+        "name": "Content Managers",
+        "slug": "content-managers",
+        "summary": "Create, review, and publish content confidently.",
+        "description": "Content managers find workflows, editorial tools, and tips for collaborating with their teams inside Strapi.",
+        "resources": [
+          {
+            "title": "Review Workflows",
+            "summary": "Coordinate your editorial process with approval stages.",
+            "url": "https://docs.strapi.io/user-docs/latest/content-manager/review-workflows"
+          }
+        ]
+      }
+    ],
+    "collections": [
+      {
+        "title": "Getting Started",
+        "slug": "getting-started",
+        "summary": "Spin up Strapi and ship your first project in minutes.",
+        "description": "Learn how to install Strapi, model data structures, and invite teammates to collaborate.",
+        "audienceSlugs": [
+          "developers",
+          "content-managers"
+        ],
+        "resources": [
+          {
+            "title": "Starter Templates",
+            "summary": "Kickstart a new project with ready-to-use templates.",
+            "url": "https://strapi.io/starters"
+          }
+        ]
+      },
+      {
+        "title": "Customization",
+        "slug": "customization",
+        "summary": "Tailor Strapi to match your product and brand.",
+        "description": "Extend Strapi with custom code, tweak the admin, and connect to external services.",
+        "audienceSlugs": [
+          "developers"
+        ],
+        "resources": [
+          {
+            "title": "Design System",
+            "summary": "Use Strapi's design system to create cohesive admin UI extensions.",
+            "url": "https://design-system.strapi.io"
+          }
+        ]
+      }
+    ],
+    "articles": [
+      {
+        "title": "Install Strapi locally",
+        "slug": "install-strapi-locally",
+        "summary": "Use the CLI to install dependencies and launch Strapi on your machine.",
+        "sections": [
+          {
+            "title": "Create a new project",
+            "body": "Run `npx create-strapi-app@latest my-project` and follow the interactive prompts to scaffold a Strapi app."
+          },
+          {
+            "title": "Start developing",
+            "body": "Navigate into your project folder, install dependencies, then run `npm run develop` to open the admin panel."
+          }
+        ],
+        "resources": [
+          {
+            "title": "Quick Start Guide",
+            "summary": "Complete walkthrough for the Strapi CLI",
+            "url": "https://docs.strapi.io/dev-docs/quick-start"
+          }
+        ],
+        "collectionSlugs": [
+          "getting-started"
+        ],
+        "audienceSlugs": [
+          "developers"
+        ]
+      },
+      {
+        "title": "Model content with the Content-Type Builder",
+        "slug": "model-content-with-the-content-type-builder",
+        "summary": "Use the Content-Type Builder to create structured collection types.",
+        "sections": [
+          {
+            "title": "Open the builder",
+            "body": "From the admin panel sidebar, choose *Content-Type Builder* and create a new collection type."
+          },
+          {
+            "title": "Add fields",
+            "body": "Drag and drop the fields your team needs, then save and wait for Strapi to restart before using the new type."
+          }
+        ],
+        "resources": [
+          {
+            "title": "Field Reference",
+            "summary": "Understand each field type and when to use it.",
+            "url": "https://docs.strapi.io/user-docs/latest/content-type-builder/fields"
+          }
+        ],
+        "collectionSlugs": [
+          "getting-started"
+        ],
+        "audienceSlugs": [
+          "content-managers"
+        ]
+      },
+      {
+        "title": "Customize the Strapi admin UI",
+        "slug": "customize-the-strapi-admin-ui",
+        "summary": "Brand the admin panel and extend it with custom React components.",
+        "sections": [
+          {
+            "title": "Override styles",
+            "body": "Create an admin extension folder and provide custom themes to align Strapi with your product colors."
+          },
+          {
+            "title": "Inject new views",
+            "body": "Register new menu links and React components to surface additional project tooling directly inside Strapi."
+          }
+        ],
+        "resources": [
+          {
+            "title": "Admin Customization",
+            "summary": "Learn how to extend the Strapi admin app.",
+            "url": "https://docs.strapi.io/dev-docs/admin-customization"
+          }
+        ],
+        "collectionSlugs": [
+          "customization"
+        ],
+        "audienceSlugs": [
+          "developers"
+        ]
+      }
+    ],
+    "releaseNotes": [
+      {
+        "title": "April 2024 release",
+        "slug": "april-2024-release",
+        "summary": "Bulk publishing improvements and brand-new admin customization options.",
+        "releasedAt": "2024-04-15",
+        "sections": [
+          {
+            "title": "Bulk publish content",
+            "body": "Publish multiple entries at once directly from the Content Manager with new bulk actions."
+          },
+          {
+            "title": "Extensible admin",
+            "body": "Admin extensions now support lifecycle hooks so developers can react to navigation changes and API events."
+          }
+        ],
+        "resources": [
+          {
+            "title": "Release Blog Post",
+            "summary": "Deep dive into everything new in April.",
+            "url": "https://strapi.io/blog"
+          }
+        ],
+        "audienceSlugs": [
+          "developers",
+          "content-managers"
+        ],
+        "articleSlugs": [
+          "model-content-with-the-content-type-builder",
+          "customize-the-strapi-admin-ui"
+        ]
+      }
+    ]
+  }
 }

--- a/src/api/knowledge-base-article/content-types/knowledge-base-article/schema.json
+++ b/src/api/knowledge-base-article/content-types/knowledge-base-article/schema.json
@@ -1,0 +1,54 @@
+{
+  "kind": "collectionType",
+  "collectionName": "knowledge_base_articles",
+  "info": {
+    "singularName": "knowledge-base-article",
+    "pluralName": "knowledge-base-articles",
+    "displayName": "Knowledge Base Article",
+    "description": "How-to and conceptual knowledge base articles"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title"
+    },
+    "summary": {
+      "type": "text"
+    },
+    "sections": {
+      "type": "component",
+      "repeatable": true,
+      "component": "knowledge-base.section"
+    },
+    "resources": {
+      "type": "component",
+      "repeatable": true,
+      "component": "knowledge-base.resource"
+    },
+    "collections": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::knowledge-base-collection.knowledge-base-collection",
+      "inversedBy": "articles"
+    },
+    "audiences": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::knowledge-base-audience.knowledge-base-audience",
+      "inversedBy": "articles"
+    },
+    "release_notes": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::knowledge-base-release-note.knowledge-base-release-note",
+      "mappedBy": "articles"
+    }
+  }
+}

--- a/src/api/knowledge-base-article/controllers/knowledge-base-article.js
+++ b/src/api/knowledge-base-article/controllers/knowledge-base-article.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * knowledge-base-article controller.
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::knowledge-base-article.knowledge-base-article');

--- a/src/api/knowledge-base-article/routes/knowledge-base-article.js
+++ b/src/api/knowledge-base-article/routes/knowledge-base-article.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * knowledge-base-article router.
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::knowledge-base-article.knowledge-base-article');

--- a/src/api/knowledge-base-article/services/knowledge-base-article.js
+++ b/src/api/knowledge-base-article/services/knowledge-base-article.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * knowledge-base-article service.
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::knowledge-base-article.knowledge-base-article');

--- a/src/api/knowledge-base-audience/content-types/knowledge-base-audience/schema.json
+++ b/src/api/knowledge-base-audience/content-types/knowledge-base-audience/schema.json
@@ -1,0 +1,52 @@
+{
+  "kind": "collectionType",
+  "collectionName": "knowledge_base_audiences",
+  "info": {
+    "singularName": "knowledge-base-audience",
+    "pluralName": "knowledge-base-audiences",
+    "displayName": "Knowledge Base Audience",
+    "description": "Audience segments for the knowledge base"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "name": {
+      "type": "string",
+      "required": true
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "name"
+    },
+    "summary": {
+      "type": "text"
+    },
+    "description": {
+      "type": "richtext"
+    },
+    "resources": {
+      "type": "component",
+      "repeatable": true,
+      "component": "knowledge-base.resource"
+    },
+    "collections": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::knowledge-base-collection.knowledge-base-collection",
+      "mappedBy": "audiences"
+    },
+    "articles": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::knowledge-base-article.knowledge-base-article",
+      "mappedBy": "audiences"
+    },
+    "release_notes": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::knowledge-base-release-note.knowledge-base-release-note",
+      "mappedBy": "audiences"
+    }
+  }
+}

--- a/src/api/knowledge-base-audience/controllers/knowledge-base-audience.js
+++ b/src/api/knowledge-base-audience/controllers/knowledge-base-audience.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * knowledge-base-audience controller.
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::knowledge-base-audience.knowledge-base-audience');

--- a/src/api/knowledge-base-audience/routes/knowledge-base-audience.js
+++ b/src/api/knowledge-base-audience/routes/knowledge-base-audience.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * knowledge-base-audience router.
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::knowledge-base-audience.knowledge-base-audience');

--- a/src/api/knowledge-base-audience/services/knowledge-base-audience.js
+++ b/src/api/knowledge-base-audience/services/knowledge-base-audience.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * knowledge-base-audience service.
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::knowledge-base-audience.knowledge-base-audience');

--- a/src/api/knowledge-base-collection/content-types/knowledge-base-collection/schema.json
+++ b/src/api/knowledge-base-collection/content-types/knowledge-base-collection/schema.json
@@ -1,0 +1,46 @@
+{
+  "kind": "collectionType",
+  "collectionName": "knowledge_base_collections",
+  "info": {
+    "singularName": "knowledge-base-collection",
+    "pluralName": "knowledge-base-collections",
+    "displayName": "Knowledge Base Collection",
+    "description": "Curated groups of knowledge base articles"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title"
+    },
+    "summary": {
+      "type": "text"
+    },
+    "description": {
+      "type": "richtext"
+    },
+    "resources": {
+      "type": "component",
+      "repeatable": true,
+      "component": "knowledge-base.resource"
+    },
+    "audiences": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::knowledge-base-audience.knowledge-base-audience",
+      "inversedBy": "collections"
+    },
+    "articles": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::knowledge-base-article.knowledge-base-article",
+      "mappedBy": "collections"
+    }
+  }
+}

--- a/src/api/knowledge-base-collection/controllers/knowledge-base-collection.js
+++ b/src/api/knowledge-base-collection/controllers/knowledge-base-collection.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * knowledge-base-collection controller.
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::knowledge-base-collection.knowledge-base-collection');

--- a/src/api/knowledge-base-collection/routes/knowledge-base-collection.js
+++ b/src/api/knowledge-base-collection/routes/knowledge-base-collection.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * knowledge-base-collection router.
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::knowledge-base-collection.knowledge-base-collection');

--- a/src/api/knowledge-base-collection/services/knowledge-base-collection.js
+++ b/src/api/knowledge-base-collection/services/knowledge-base-collection.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * knowledge-base-collection service.
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::knowledge-base-collection.knowledge-base-collection');

--- a/src/api/knowledge-base-global/content-types/knowledge-base-global/schema.json
+++ b/src/api/knowledge-base-global/content-types/knowledge-base-global/schema.json
@@ -1,0 +1,37 @@
+{
+  "kind": "collectionType",
+  "collectionName": "knowledge_base_globals",
+  "info": {
+    "singularName": "knowledge-base-global",
+    "pluralName": "knowledge-base-globals",
+    "displayName": "Knowledge Base Global",
+    "description": "Global configuration for the knowledge base"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title"
+    },
+    "summary": {
+      "type": "text"
+    },
+    "heroTitle": {
+      "type": "string"
+    },
+    "heroDescription": {
+      "type": "text"
+    },
+    "resources": {
+      "type": "component",
+      "repeatable": true,
+      "component": "knowledge-base.resource"
+    }
+  }
+}

--- a/src/api/knowledge-base-global/controllers/knowledge-base-global.js
+++ b/src/api/knowledge-base-global/controllers/knowledge-base-global.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * knowledge-base-global controller.
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::knowledge-base-global.knowledge-base-global');

--- a/src/api/knowledge-base-global/routes/knowledge-base-global.js
+++ b/src/api/knowledge-base-global/routes/knowledge-base-global.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * knowledge-base-global router.
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::knowledge-base-global.knowledge-base-global');

--- a/src/api/knowledge-base-global/services/knowledge-base-global.js
+++ b/src/api/knowledge-base-global/services/knowledge-base-global.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * knowledge-base-global service.
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::knowledge-base-global.knowledge-base-global');

--- a/src/api/knowledge-base-release-note/content-types/knowledge-base-release-note/schema.json
+++ b/src/api/knowledge-base-release-note/content-types/knowledge-base-release-note/schema.json
@@ -1,0 +1,51 @@
+{
+  "kind": "collectionType",
+  "collectionName": "knowledge_base_release_notes",
+  "info": {
+    "singularName": "knowledge-base-release-note",
+    "pluralName": "knowledge-base-release-notes",
+    "displayName": "Knowledge Base Release Note",
+    "description": "Release notes that surface knowledge base updates"
+  },
+  "options": {
+    "draftAndPublish": true
+  },
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "slug": {
+      "type": "uid",
+      "targetField": "title"
+    },
+    "summary": {
+      "type": "text"
+    },
+    "releasedAt": {
+      "type": "date"
+    },
+    "sections": {
+      "type": "component",
+      "repeatable": true,
+      "component": "knowledge-base.section"
+    },
+    "resources": {
+      "type": "component",
+      "repeatable": true,
+      "component": "knowledge-base.resource"
+    },
+    "audiences": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::knowledge-base-audience.knowledge-base-audience",
+      "inversedBy": "release_notes"
+    },
+    "articles": {
+      "type": "relation",
+      "relation": "manyToMany",
+      "target": "api::knowledge-base-article.knowledge-base-article",
+      "inversedBy": "release_notes"
+    }
+  }
+}

--- a/src/api/knowledge-base-release-note/controllers/knowledge-base-release-note.js
+++ b/src/api/knowledge-base-release-note/controllers/knowledge-base-release-note.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * knowledge-base-release-note controller.
+ */
+
+const { createCoreController } = require('@strapi/strapi').factories;
+
+module.exports = createCoreController('api::knowledge-base-release-note.knowledge-base-release-note');

--- a/src/api/knowledge-base-release-note/routes/knowledge-base-release-note.js
+++ b/src/api/knowledge-base-release-note/routes/knowledge-base-release-note.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * knowledge-base-release-note router.
+ */
+
+const { createCoreRouter } = require('@strapi/strapi').factories;
+
+module.exports = createCoreRouter('api::knowledge-base-release-note.knowledge-base-release-note');

--- a/src/api/knowledge-base-release-note/services/knowledge-base-release-note.js
+++ b/src/api/knowledge-base-release-note/services/knowledge-base-release-note.js
@@ -1,0 +1,9 @@
+'use strict';
+
+/**
+ * knowledge-base-release-note service.
+ */
+
+const { createCoreService } = require('@strapi/strapi').factories;
+
+module.exports = createCoreService('api::knowledge-base-release-note.knowledge-base-release-note');

--- a/src/components/knowledge-base/resource.json
+++ b/src/components/knowledge-base/resource.json
@@ -1,0 +1,21 @@
+{
+  "collectionName": "components_knowledge_base_resources",
+  "info": {
+    "displayName": "Resource",
+    "description": "Link to supporting knowledge base material"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string",
+      "required": true
+    },
+    "summary": {
+      "type": "text"
+    },
+    "url": {
+      "type": "string",
+      "required": true
+    }
+  }
+}

--- a/src/components/knowledge-base/section.json
+++ b/src/components/knowledge-base/section.json
@@ -1,0 +1,16 @@
+{
+  "collectionName": "components_knowledge_base_sections",
+  "info": {
+    "displayName": "Section",
+    "description": "Structured article or release note section"
+  },
+  "options": {},
+  "attributes": {
+    "title": {
+      "type": "string"
+    },
+    "body": {
+      "type": "richtext"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add knowledge base content types, controllers, routes, and shared components for resources and sections
- seed knowledge base globals, audiences, collections, articles, and release notes with relations resolved by slug
- expose new APIs and permissions while extending bootstrap/seed data to load the knowledge base content

## Testing
- npm run seed:example *(fails: middleware requires app keys in config/server.js)*

------
https://chatgpt.com/codex/tasks/task_b_68cd50fd38108329ac6a015a0a9aa375